### PR TITLE
Standardize on `body` instead of implicit return

### DIFF
--- a/wall_b.rb
+++ b/wall_b.rb
@@ -100,14 +100,14 @@ get("/") do
   # See:
   # * User docs: http://datamapper.org/docs/find.html
   # * Method docs: http://rdoc.info/github/datamapper/dm-core/DataMapper/Collection#all-instance_method
-  erb(:home, :locals => {:walls => walls}) 
+  body(erb(:home, :locals => {:walls => walls}))
 end
 
 get("/walls/new") do
   wall = Wall.new()
   # We're going to create a new wall, since `views/new_wall.erb` requires a
   # `@wall` instance variable to auto-fill in the form.
-  erb(:new_wall, :locals => {:wall => wall})
+  body(erb(:new_wall, :locals => {:wall => wall}))
 end
 
 post("/walls") do
@@ -125,10 +125,10 @@ post("/walls") do
   # * Method docs for create: http://rdoc.info/github/datamapper/dm-core/DataMapper/Model#create-instance_method
 
   if @wall.saved?()
-    redirect "/"
+    redirect("/")
     # If we successfuly create the wall, let's send the user back home.
   else
-    erb(:new_wall)
+    body(erb(:new_wall))
     # If we *can't* create the wall; We'll redisplay the form so the user can
     # fix any errors.
   end


### PR DESCRIPTION
This also fixes #6, as there was a few missing parens.
