### PR TITLE
rerun -x waits for the process to complete before watching

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Read our [guide for installing SQLite3][sqlite3-install].
 1. Fork and clone this repository
 1. `bundle install --without production`
 1. `cp .env.example .env`
-1. `bundle exec rerun -x rackup` # Watches your files and re-starts the app on save.
+1. `bundle exec rerun -c rackup` # Watches your files and re-starts the app on save.
 
 ## Pushing to Production
 


### PR DESCRIPTION
`rerun -x` waits for the process to terminate before it starts watching the files for changes. This makes it mostly useful for running tests or other processes that start and end. 

`rerun -c` tells the screen to clear each time it restarts the process. Useful for clearing out scrollback for previous errors. (You can still scroll up to see it, thankfully)
